### PR TITLE
add: 장바구니 API 추가

### DIFF
--- a/src/main/java/Dolphin/ShoppingCart/domain/student/api/BucketController.java
+++ b/src/main/java/Dolphin/ShoppingCart/domain/student/api/BucketController.java
@@ -49,4 +49,31 @@ public class BucketController {
         bucketService.updateAlternateCourse(studentId, request);
         return BaseResponse.onSuccess(SuccessStatus.OK, null);
     }
+
+    @GetMapping("/list")
+    public BaseResponse<List<BucketSummaryDTO>> getMyBuckets() {
+        Long studentId = 1L; // JWT 적용 전 임시 ID
+        return BaseResponse.onSuccess(SuccessStatus.OK, bucketService.getMyBuckets(studentId));
+    }
+
+    @PostMapping("/create")
+    public BaseResponse<Void> createBucket(@RequestBody BucketCreateRequestDTO request) {
+        Long studentId = 1L;
+        bucketService.createBucket(studentId, request);
+        return BaseResponse.onSuccess(SuccessStatus.OK, null);
+    }
+
+    @PatchMapping("/best")
+    public BaseResponse<Void> setBestBucket(@RequestBody BucketSelectRequestDTO request) {
+        Long studentId = 1L;
+        bucketService.setBestBucket(studentId, request);
+        return BaseResponse.onSuccess(SuccessStatus.OK, null);
+    }
+
+    @DeleteMapping("/cart/{bucketId}")
+    public BaseResponse<Void> deleteBucket(@PathVariable Long bucketId) {
+        Long studentId = 1L;
+        bucketService.deleteBucket(studentId, bucketId);
+        return BaseResponse.onSuccess(SuccessStatus.OK, null);
+    }
 }

--- a/src/main/java/Dolphin/ShoppingCart/domain/student/application/BucketService.java
+++ b/src/main/java/Dolphin/ShoppingCart/domain/student/application/BucketService.java
@@ -9,4 +9,8 @@ public interface BucketService {
     void deleteCourse(Long studentId, Long bucketElementId);
     void updatePriorities(Long studentId, List<BucketPriorityRequestDTO> requests);
     void updateAlternateCourse(Long studentId, BucketAlternateRequestDTO request);
+    List<BucketSummaryDTO> getMyBuckets(Long studentId);
+    void createBucket(Long studentId, BucketCreateRequestDTO request);
+    void deleteBucket(Long studentId, Long bucketId);
+    void setBestBucket(Long studentId, BucketSelectRequestDTO request);
 }

--- a/src/main/java/Dolphin/ShoppingCart/domain/student/dto/bucket/BucketCreateRequestDTO.java
+++ b/src/main/java/Dolphin/ShoppingCart/domain/student/dto/bucket/BucketCreateRequestDTO.java
@@ -1,0 +1,10 @@
+package Dolphin.ShoppingCart.domain.student.dto.bucket;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BucketCreateRequestDTO {
+    private String name; // 장바구니 이름 (예: "플랜 A", "망하면 이거")
+}

--- a/src/main/java/Dolphin/ShoppingCart/domain/student/dto/bucket/BucketSelectRequestDTO.java
+++ b/src/main/java/Dolphin/ShoppingCart/domain/student/dto/bucket/BucketSelectRequestDTO.java
@@ -1,0 +1,10 @@
+package Dolphin.ShoppingCart.domain.student.dto.bucket;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BucketSelectRequestDTO {
+    private Long bucketId; // 대표로 설정할 장바구니 ID
+}

--- a/src/main/java/Dolphin/ShoppingCart/domain/student/dto/bucket/BucketSummaryDTO.java
+++ b/src/main/java/Dolphin/ShoppingCart/domain/student/dto/bucket/BucketSummaryDTO.java
@@ -1,0 +1,15 @@
+package Dolphin.ShoppingCart.domain.student.dto.bucket;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BucketSummaryDTO {
+    private Long bucketId;
+    private String name;
+    private Boolean isBest; // 현재 대표 장바구니 여부
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/Dolphin/ShoppingCart/domain/student/entity/Student.java
+++ b/src/main/java/Dolphin/ShoppingCart/domain/student/entity/Student.java
@@ -48,4 +48,8 @@ public class Student extends BaseEntity {
     public void updateReactionTime(Double avgReactionTime) {
         this.avgReactionTime = avgReactionTime;
     }
+
+    public void changeBestBucket(Long bucketId) {
+        this.bestBucket = bucketId;
+    }
 }

--- a/src/main/java/Dolphin/ShoppingCart/domain/student/repository/BucketRepository.java
+++ b/src/main/java/Dolphin/ShoppingCart/domain/student/repository/BucketRepository.java
@@ -1,7 +1,10 @@
 package Dolphin.ShoppingCart.domain.student.repository;
 
 import Dolphin.ShoppingCart.domain.student.entity.Bucket;
+import Dolphin.ShoppingCart.domain.student.entity.Student;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BucketRepository extends JpaRepository<Bucket, Long>{
+    List<Bucket> findAllByStudent(Student student);
 }

--- a/src/test/java/BucketServiceTest.java
+++ b/src/test/java/BucketServiceTest.java
@@ -3,11 +3,8 @@ import Dolphin.ShoppingCart.domain.course.entity.Course;
 import Dolphin.ShoppingCart.domain.course.entity.Teach;
 import Dolphin.ShoppingCart.domain.course.enums.MajorType;
 import Dolphin.ShoppingCart.domain.course.repository.TeachRepository;
-import Dolphin.ShoppingCart.domain.student.application.BucketServiceImpl; // 추가된 Import
-import Dolphin.ShoppingCart.domain.student.dto.bucket.BucketAddRequestDTO;
-import Dolphin.ShoppingCart.domain.student.dto.bucket.BucketAlternateRequestDTO;
-import Dolphin.ShoppingCart.domain.student.dto.bucket.BucketPriorityRequestDTO;
-import Dolphin.ShoppingCart.domain.student.dto.bucket.BucketResponseDTO;
+import Dolphin.ShoppingCart.domain.student.application.BucketServiceImpl;
+import Dolphin.ShoppingCart.domain.student.dto.bucket.*;
 import Dolphin.ShoppingCart.domain.student.entity.Bucket;
 import Dolphin.ShoppingCart.domain.student.entity.BucketElement;
 import Dolphin.ShoppingCart.domain.student.entity.Student;
@@ -31,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,6 +46,8 @@ class BucketServiceTest {
     @Mock
     private TeachRepository teachRepository;
 
+    // --- 기존 테스트: 장바구니 내용물 관리 ---
+
     @Test
     @DisplayName("장바구니 목록 조회 성공")
     void getBucketList_Success() {
@@ -55,16 +55,13 @@ class BucketServiceTest {
         Long studentId = 1L;
         Long bucketId = 100L;
 
-        // Student & Bucket
         Student student = createStudent(studentId, bucketId);
         Bucket bucket = createBucket(bucketId, student);
 
-        // Teach & Course & Professor
         Course course = Course.builder().name("자료구조").majority(MajorType.MAJOR_REQUIRED).build();
         Professor professor = Professor.builder().professorName("김교수").build();
         Teach teach = Teach.builder().id(200L).course(course).professor(professor).build();
 
-        // BucketElement
         BucketElement element = BucketElement.builder()
                 .id(10L)
                 .bucket(bucket)
@@ -81,7 +78,6 @@ class BucketServiceTest {
         // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getCourseName()).isEqualTo("자료구조");
-        assertThat(result.get(0).getProfessorName()).isEqualTo("김교수");
     }
 
     @Test
@@ -117,7 +113,6 @@ class BucketServiceTest {
     @Test
     @DisplayName("장바구니 과목 삭제 성공")
     void deleteCourse_Success() {
-        // given
         Long studentId = 1L;
         Long bucketId = 100L;
         Long elementId = 10L;
@@ -128,17 +123,14 @@ class BucketServiceTest {
 
         given(bucketElementRepository.findById(elementId)).willReturn(Optional.of(element));
 
-        // when
         bucketService.deleteCourse(studentId, elementId);
 
-        // then
         verify(bucketElementRepository).delete(element);
     }
 
     @Test
     @DisplayName("장바구니 과목 삭제 실패 - 내 장바구니가 아님")
     void deleteCourse_Fail_Forbidden() {
-        // given
         Long myStudentId = 1L;
         Long otherStudentId = 2L;
         Long bucketId = 100L;
@@ -150,7 +142,6 @@ class BucketServiceTest {
 
         given(bucketElementRepository.findById(elementId)).willReturn(Optional.of(element));
 
-        // when & then
         assertThatThrownBy(() -> bucketService.deleteCourse(myStudentId, elementId))
                 .isInstanceOf(StudentException.class)
                 .extracting("code")
@@ -160,14 +151,12 @@ class BucketServiceTest {
     @Test
     @DisplayName("우선순위 변경 성공")
     void updatePriorities_Success() {
-        // given
         Long studentId = 1L;
         Long bucketId = 100L;
         Long elementId = 10L;
 
         Student student = createStudent(studentId, bucketId);
         Bucket bucket = createBucket(bucketId, student);
-
         BucketElement element = new BucketElement(elementId, null, bucket, 1, null, null);
 
         BucketPriorityRequestDTO request = new BucketPriorityRequestDTO();
@@ -176,17 +165,14 @@ class BucketServiceTest {
 
         given(bucketElementRepository.findById(elementId)).willReturn(Optional.of(element));
 
-        // when
         bucketService.updatePriorities(studentId, List.of(request));
 
-        // then
         assertThat(element.getPriority()).isEqualTo(2);
     }
 
     @Test
     @DisplayName("대체과목 설정 성공")
     void updateAlternateCourse_Success() {
-        // given
         Long studentId = 1L;
         Long bucketId = 100L;
         Long targetElementId = 10L;
@@ -208,11 +194,173 @@ class BucketServiceTest {
         given(bucketElementRepository.findByBucketIdAndTeachId(bucketId, alternateTeachId))
                 .willReturn(Optional.of(altElement));
 
-        // when
         bucketService.updateAlternateCourse(studentId, request);
 
-        // then
         assertThat(targetElement.getSubElement()).isEqualTo(altElement);
+    }
+
+    // --- 신규 테스트: 장바구니 자체 관리 (생성, 조회, 대표설정, 삭제) ---
+
+    @Test
+    @DisplayName("내 장바구니 목록 조회 성공")
+    void getMyBuckets_Success() {
+        // given
+        Long studentId = 1L;
+        Student student = createStudent(studentId, 100L); // 대표 장바구니 ID: 100
+
+        Bucket bucket1 = Bucket.builder().id(100L).name("플랜A").student(student).build();
+        Bucket bucket2 = Bucket.builder().id(101L).name("플랜B").student(student).build();
+
+        given(studentRepository.findById(studentId)).willReturn(Optional.of(student));
+        given(bucketRepository.findAllByStudent(student)).willReturn(List.of(bucket1, bucket2));
+
+        // when
+        List<BucketSummaryDTO> results = bucketService.getMyBuckets(studentId);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).getName()).isEqualTo("플랜A");
+        assertThat(results.get(0).getIsBest()).isTrue(); // 100번이 대표이므로 True
+        assertThat(results.get(1).getName()).isEqualTo("플랜B");
+        assertThat(results.get(1).getIsBest()).isFalse();
+    }
+
+    @Test
+    @DisplayName("장바구니 생성 성공 - 첫 장바구니는 자동으로 대표 설정")
+    void createBucket_First_AutoBest() {
+        // given
+        Long studentId = 1L;
+        // 대표 장바구니가 없는 상태
+        Student student = createStudent(studentId, null);
+
+        BucketCreateRequestDTO request = new BucketCreateRequestDTO();
+        ReflectionTestUtils.setField(request, "name", "새 장바구니");
+
+        Bucket savedBucket = Bucket.builder().id(100L).student(student).build();
+
+        given(studentRepository.findById(studentId)).willReturn(Optional.of(student));
+        given(bucketRepository.save(any(Bucket.class))).willReturn(savedBucket);
+
+        // when
+        bucketService.createBucket(studentId, request);
+
+        // then
+        verify(bucketRepository).save(any(Bucket.class));
+        // 첫 장바구니였으므로 student의 bestBucket이 100L로 업데이트 되어야 함
+        assertThat(student.getBestBucket()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("장바구니 생성 성공 - 이미 대표가 있으면 그냥 생성만")
+    void createBucket_NotFirst() {
+        // given
+        Long studentId = 1L;
+        Student student = createStudent(studentId, 99L); // 이미 99번이 대표
+
+        BucketCreateRequestDTO request = new BucketCreateRequestDTO();
+        ReflectionTestUtils.setField(request, "name", "플랜B");
+
+        Bucket savedBucket = Bucket.builder().id(100L).student(student).build();
+
+        given(studentRepository.findById(studentId)).willReturn(Optional.of(student));
+        given(bucketRepository.save(any(Bucket.class))).willReturn(savedBucket);
+
+        // when
+        bucketService.createBucket(studentId, request);
+
+        // then
+        verify(bucketRepository).save(any(Bucket.class));
+        // 대표 장바구니는 여전히 99번이어야 함
+        assertThat(student.getBestBucket()).isEqualTo(99L);
+    }
+
+    @Test
+    @DisplayName("대표 장바구니 설정 성공")
+    void setBestBucket_Success() {
+        // given
+        Long studentId = 1L;
+        Long newBestBucketId = 200L;
+        Student student = createStudent(studentId, 100L); // 기존 100번
+
+        Bucket newBucket = Bucket.builder().id(newBestBucketId).student(student).build();
+
+        BucketSelectRequestDTO request = new BucketSelectRequestDTO();
+        ReflectionTestUtils.setField(request, "bucketId", newBestBucketId);
+
+        given(studentRepository.findById(studentId)).willReturn(Optional.of(student));
+        given(bucketRepository.findById(newBestBucketId)).willReturn(Optional.of(newBucket));
+
+        // when
+        bucketService.setBestBucket(studentId, request);
+
+        // then
+        assertThat(student.getBestBucket()).isEqualTo(newBestBucketId);
+    }
+
+    @Test
+    @DisplayName("장바구니 삭제 성공")
+    void deleteBucket_Success() {
+        // given
+        Long studentId = 1L;
+        Long bucketId = 200L; // 삭제할 장바구니
+        Long bestBucketId = 100L; // 대표 장바구니
+
+        Student student = createStudent(studentId, bestBucketId);
+        Bucket bucket = Bucket.builder().id(bucketId).student(student).build();
+
+        given(studentRepository.findById(studentId)).willReturn(Optional.of(student));
+        given(bucketRepository.findById(bucketId)).willReturn(Optional.of(bucket));
+
+        // when
+        bucketService.deleteBucket(studentId, bucketId);
+
+        // then
+        verify(bucketRepository).delete(bucket);
+    }
+
+    @Test
+    @DisplayName("장바구니 삭제 실패 - 대표 장바구니는 삭제 불가")
+    void deleteBucket_Fail_IsBest() {
+        // given
+        Long studentId = 1L;
+        Long bucketId = 100L; // 삭제하려는게 대표 장바구니
+
+        Student student = createStudent(studentId, bucketId);
+        Bucket bucket = Bucket.builder().id(bucketId).student(student).build();
+
+        given(studentRepository.findById(studentId)).willReturn(Optional.of(student));
+        given(bucketRepository.findById(bucketId)).willReturn(Optional.of(bucket));
+
+        // when & then
+        assertThatThrownBy(() -> bucketService.deleteBucket(studentId, bucketId))
+                .isInstanceOf(StudentException.class)
+                .extracting("code")
+                .isEqualTo(ErrorStatus._BAD_REQUEST);
+
+        verify(bucketRepository, times(0)).delete(any());
+    }
+
+    @Test
+    @DisplayName("장바구니 삭제 실패 - 내 장바구니 아님")
+    void deleteBucket_Fail_NotOwner() {
+        // given
+        Long myId = 1L;
+        Long otherId = 2L;
+        Long bucketId = 300L;
+
+        Student me = createStudent(myId, 100L);
+        Student other = createStudent(otherId, 300L);
+
+        Bucket bucket = Bucket.builder().id(bucketId).student(other).build(); // 남의꺼
+
+        given(studentRepository.findById(myId)).willReturn(Optional.of(me));
+        given(bucketRepository.findById(bucketId)).willReturn(Optional.of(bucket));
+
+        // when & then
+        assertThatThrownBy(() -> bucketService.deleteBucket(myId, bucketId))
+                .isInstanceOf(StudentException.class)
+                .extracting("code")
+                .isEqualTo(ErrorStatus._FORBIDDEN);
     }
 
     // --- Helper Methods ---


### PR DESCRIPTION
장바구니 자체 관리 API 구현
- 생성 (POST /bucket-/create): 첫 장바구니 생성 시 자동으로 '대표 장바구니'로 설정.
- 삭제 (DELETE /bucket-/cart/{bucketId}): 대표 장바구니 삭제 방지 로직 적용.
- 대표 설정 (PATCH /bucket-/best): 시뮬레이션에 사용할 메인 장바구니 지정.
- 목록 조회 (GET /bucket-/list): 내 장바구니 리스트 조회.